### PR TITLE
return only a string from Format()

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -30,7 +30,7 @@ func ExampleFormat() {
 	}
 
 	// format the parameter map
-	val, _ := httpforwarded.Format(params)
+	val := httpforwarded.Format(params)
 
 	fmt.Print(val)
 	// output: for=192.0.2.1, for=192.0.2.4; proto=http

--- a/format.go
+++ b/format.go
@@ -17,7 +17,11 @@ var bytesBufferPool = &sync.Pool{
 
 // Format is a function that takes a map[string][]string and generates the
 // appropriate content for an HTTP Forwarded header.
-func Format(params map[string][]string) (string, error) {
+func Format(params map[string][]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+
 	buf := bytesBufferPool.Get().(*bytes.Buffer)
 	buf.Reset()
 
@@ -57,7 +61,7 @@ func Format(params map[string][]string) (string, error) {
 
 	bytesBufferPool.Put(buf)
 
-	return out, nil
+	return out
 }
 
 func sortedParamKeys(params map[string][]string) []string {

--- a/format_test.go
+++ b/format_test.go
@@ -11,7 +11,9 @@ import (
 
 func (*TestSuite) TestFormat(c *C) {
 	var out string
-	var err error
+
+	out = httpforwarded.Format(nil)
+	c.Check(out, Equals, "")
 
 	params := map[string][]string{
 		"for":   []string{"192.0.2.1", "192.0.2.4"},
@@ -19,7 +21,6 @@ func (*TestSuite) TestFormat(c *C) {
 		"proto": []string{"http"},
 	}
 
-	out, err = httpforwarded.Format(params)
-	c.Assert(err, IsNil)
+	out = httpforwarded.Format(params)
 	c.Check(out, Equals, "by=192.0.2.200, by=192.0.2.202; for=192.0.2.1, for=192.0.2.4; proto=http")
 }


### PR DESCRIPTION
Based on the parameters that `Format()` takes, it doesn't seem likely an
error would be triggered trying to format the map. The only case where
that is true is if the map were nil or empty, but we can just return an
empty string in that case.
