### PR TITLE
improve handling of empty params in Parse funcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go_import_path: github.com/theckman/go-httpforwarded
+go_import_path: github.com/theckman/httpforwarded
 go:
   - 1.7.1
   - tip

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# go-httpforwarded
-[![TravisCI Build Status](https://img.shields.io/travis/theckman/go-httpforwarded/master.svg)](https://travis-ci.org/theckman/go-httpforwarded)
-[![License](https://img.shields.io/badge/license-BSD--style_3--clause-brightgreen.svg?style=flat)](https://github.com/theckman/go-httpforwarded/blob/master/LICENSE)
-[![GoDoc](https://img.shields.io/badge/GoDoc-httpforwarded-blue.svg)](https://godoc.org/github.com/theckman/go-httpforwarded)
+# httpforwarded
+[![TravisCI Build Status](https://img.shields.io/travis/theckman/httpforwarded/master.svg)](https://travis-ci.org/theckman/httpforwarded)
+[![License](https://img.shields.io/badge/license-BSD--style_3--clause-brightgreen.svg?style=flat)](https://github.com/theckman/httpforwarded/blob/master/LICENSE)
+[![GoDoc](https://img.shields.io/badge/GoDoc-httpforwarded-blue.svg)](https://godoc.org/github.com/theckman/httpforwarded)
 
 The `httpforwarded` go package provides utility functions for working with the
 `Forwarded` HTTP header as defined in [RFC-7239](https://tools.ietf.org/html/rfc7239).
@@ -16,21 +16,21 @@ function.
 This package copies some functions, without modification, from the Go standard
 library. As such, the entirety of this package is released under the same
 permissive BSD-style license as the Go language itself. Please see the contents
-of the [LICENSE](https://github.com/theckman/go-httpforwarded/blob/master/LICENSE)
+of the [LICENSE](https://github.com/theckman/httpforwarded/blob/master/LICENSE)
 file for the full details of the license.
 
 ## Installing
 To install this package for consumption, you can run the following:
 
 ```
-go get -u github.com/theckman/go-httpforwarded
+go get -u github.com/theckman/httpforwarded
 ```
 
-If you would like to also work on the development of `go-httpforwarded`, you can
+If you would like to also work on the development of `httpforwarded`, you can
 also install the testing dependencies:
 
 ```
-go get -t -u github.com/theckman/go-httpforwarded
+go get -t -u github.com/theckman/httpforwarded
 ```
 
 ## Usage
@@ -46,4 +46,4 @@ fmt.Printf("origin %s", params["for"][0])
 ```
 
 For more information on using the package, please refer to the
-[GoDoc](https://godoc.org/github.com/theckman/go-httpforwarded) page.
+[GoDoc](https://godoc.org/github.com/theckman/httpforwarded) page.

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ package httpforwarded_test
 import (
 	"fmt"
 
-	"github.com/theckman/go-httpforwarded"
+	"github.com/theckman/httpforwarded"
 )
 
 func ExampleParse() {

--- a/format_test.go
+++ b/format_test.go
@@ -5,7 +5,7 @@
 package httpforwarded_test
 
 import (
-	httpforwarded "github.com/theckman/go-httpforwarded"
+	"github.com/theckman/httpforwarded"
 	. "gopkg.in/check.v1"
 )
 

--- a/parse.go
+++ b/parse.go
@@ -21,6 +21,10 @@ import (
 // This function was inspired by the mime.ParseMediaType() function in the
 // Go stdlib.
 func Parse(values []string) (map[string][]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
 	params := make(map[string][]string)
 
 	for _, v := range values {
@@ -64,6 +68,14 @@ func Parse(values []string) (map[string][]string, error) {
 // ParseParameter parses the Forwarded header values and returns a slice of
 // parameter values. The paramName parameter should be a lowercase string.
 func ParseParameter(paramName string, values []string) ([]string, error) {
+	if paramName == "" {
+		return nil, errors.New(`paramName must not be ""`)
+	}
+
+	if len(values) == 0 {
+		return nil, nil
+	}
+
 	paramValues := make([]string, 0, 2)
 
 	for _, v := range values {

--- a/parse_test.go
+++ b/parse_test.go
@@ -5,16 +5,32 @@
 package httpforwarded_test
 
 import (
-	"github.com/theckman/go-httpforwarded"
+	"github.com/theckman/httpforwarded"
 	. "gopkg.in/check.v1"
 )
 
 func (*TestSuite) TestParse(c *C) {
+	testParseMisc(c)
 	testParseSingleParam(c)
 	testParseMultiParam(c)
 	testParseMultiLine(c)
 	testParseMultiParamValue(c)
 	testParseAllTheThings(c)
+}
+
+func testParseMisc(c *C) {
+	var err error
+	var vals map[string][]string
+
+	vals, err = httpforwarded.Parse(nil)
+	c.Check(err, IsNil)
+	c.Check(vals, IsNil)
+
+	var values []string
+
+	vals, err = httpforwarded.Parse(values)
+	c.Check(err, IsNil)
+	c.Check(vals, IsNil)
 }
 
 func testParseSingleParam(c *C) {
@@ -139,10 +155,32 @@ func testParseAllTheThings(c *C) {
 }
 
 func (*TestSuite) TestParseParameter(c *C) {
+	testParseParameterMisc(c)
 	testParseParameterSingleParam(c)
 	testParseParameterMultiParam(c)
 	testParseParameterMultiLine(c)
 	testParseParameterAllTheThings(c)
+}
+
+func testParseParameterMisc(c *C) {
+	var err error
+	var vals []string
+
+	vals, err = httpforwarded.ParseParameter("for", nil)
+	c.Check(err, IsNil)
+	c.Check(vals, IsNil)
+
+	var values []string
+
+	vals, err = httpforwarded.ParseParameter("for", values)
+	c.Check(err, IsNil)
+	c.Check(vals, IsNil)
+
+	values = []string{"for=192.0.2.1"}
+
+	vals, err = httpforwarded.ParseParameter("", values)
+	c.Check(err, ErrorMatches, `paramName must not be ""`)
+	c.Check(vals, IsNil)
 }
 
 func testParseParameterSingleParam(c *C) {


### PR DESCRIPTION
This improves the handling of parameters with the `Parse*` functions.
Specifically, when the parameters are the empty value for HTTP headers
(empty []string) the functions short-circuit and return nil.

This also renames the `github.com/theckman/go-httpforwarded` import to
`github.com/theckman/httpforwarded`.
