### PR TITLE
Provide a ParseFromRequest helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ go get -t -u github.com/theckman/httpforwarded
 ```
 
 ## Usage
+
+Given a `*http.Request`:
+
+```Go
+// var req *http.Request
+
+params, _ := httpforwarded.ParseFromRequest(req)
+
+// you can then do something like this to get the first "for" param:
+fmt.Printf("origin %s", params["for"][0])
+```
+
+Given a list of `Forwarded` header values:
+
 ```Go
 // var req *http.Request
 

--- a/parse.go
+++ b/parse.go
@@ -8,6 +8,7 @@ package httpforwarded
 import (
 	"bytes"
 	"errors"
+	"net/http"
 	"strings"
 	"unicode"
 )
@@ -63,6 +64,14 @@ func Parse(values []string) (map[string][]string, error) {
 	}
 
 	return params, nil
+}
+
+// ParseFromRequest is a helper function that is identical to Parse, except that
+// it automatically extracts the "Forwarded" header values from the *http.Request.
+func ParseFromRequest(req *http.Request) (map[string][]string, error) {
+	headerValues := req.Header[http.CanonicalHeaderKey("forwarded")]
+
+	return Parse(headerValues)
 }
 
 // ParseParameter parses the Forwarded header values and returns a slice of

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,6 +7,7 @@ package httpforwarded_test
 import (
 	"github.com/theckman/httpforwarded"
 	. "gopkg.in/check.v1"
+	"net/http"
 )
 
 func (*TestSuite) TestParse(c *C) {
@@ -16,6 +17,7 @@ func (*TestSuite) TestParse(c *C) {
 	testParseMultiLine(c)
 	testParseMultiParamValue(c)
 	testParseAllTheThings(c)
+	testParseFromRequest(c)
 }
 
 func testParseMisc(c *C) {
@@ -152,6 +154,24 @@ func testParseAllTheThings(c *C) {
 	c.Assert(len(by), Equals, 2)
 	c.Check(by[0], Equals, "192.0.2.200")
 	c.Check(by[1], Equals, "192.0.2.202")
+}
+
+func testParseFromRequest(c *C) {
+	var err error
+	var params map[string][]string
+
+	req := &http.Request{Header: map[string][]string{
+		"Forwarded": {"for=192.0.2.1"},
+	}}
+
+	params, err = httpforwarded.ParseFromRequest(req)
+	c.Assert(err, IsNil)
+	c.Check(len(params), Equals, 1)
+
+	forVal, ok := params["for"]
+	c.Assert(ok, Equals, true)
+	c.Assert(len(forVal), Equals, 1)
+	c.Check(forVal[0], Equals, "192.0.2.1")
 }
 
 func (*TestSuite) TestParseParameter(c *C) {


### PR DESCRIPTION
Problem: `Forwarded` header is standardized, yet there's a burden on the user to manually extract it from the `*http.Request`.

Solution: provide a `ParseFromRequest` helper function.